### PR TITLE
Optimize data_block_hash_index unit test

### DIFF
--- a/table/block_based/data_block_hash_index_test.cc
+++ b/table/block_based/data_block_hash_index_test.cc
@@ -113,7 +113,7 @@ TEST(DataBlockHashIndex, DataBlockHashTestSmall) {
 TEST(DataBlockHashIndex, DataBlockHashTest) {
   // bucket_num = 200, #keys = 100. 50% utilization
   DataBlockHashIndexBuilder builder;
-  builder.Initialize(0.75 /*util_ratio*/);
+  builder.Initialize(0.5 /*util_ratio*/);
 
   for (uint8_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
@@ -148,9 +148,9 @@ TEST(DataBlockHashIndex, DataBlockHashTest) {
 }
 
 TEST(DataBlockHashIndex, DataBlockHashTestCollision) {
-  // bucket_num = 2. There will be intense hash collisions
+  // bucket_num = 11, #keys = 100. 1000% utilization There will be intense hash collisions
   DataBlockHashIndexBuilder builder;
-  builder.Initialize(0.75 /*util_ratio*/);
+  builder.Initialize(10.0 /*util_ratio*/);
 
   for (uint8_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
@@ -173,15 +173,22 @@ TEST(DataBlockHashIndex, DataBlockHashTestCollision) {
   DataBlockHashIndex index;
   uint16_t map_offset;
   index.Initialize(s.data(), static_cast<uint16_t>(s.size()), &map_offset);
-
+  
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, map_offset);
+  size_t collision_count = 0;
   for (uint8_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
     uint8_t restart_point = i;
+    uint8_t entry = index.Lookup(data, map_offset, key);
+    if (entry == kCollision) {
+      collision_count++;
+    }
     ASSERT_TRUE(
         SearchForOffset(index, s.data(), map_offset, key, restart_point));
   }
+  // bucket_num = 11, #keys = 100, so that there will be at least 90 hash collisions
+  ASSERT_GE(collision_count, 90);
 }
 
 TEST(DataBlockHashIndex, DataBlockHashTestLarge) {


### PR DESCRIPTION
(1) DataBlockHashTest : Keep comments consistent with code behavior, 50% utilization -> 0.5 util_ratio
(2) DataBlockHashTestCollision: The original implementation is consistent with DataBlockHashTest, and it is not designed for a large number of conflicting scenarios. I have made a repair